### PR TITLE
Properly exit switch case

### DIFF
--- a/basic_ingest.module
+++ b/basic_ingest.module
@@ -27,6 +27,8 @@ function basic_ingest_help($route_name, RouteMatchInterface $route_match) {
 <p>Uncheck 'Published' to keep this Repository Item out of public view. Unpublished items will still be preserved.</p>
 EOHELP;
       }
+      break;
+
     case 'entity.media.add_form':
     case 'entity.media.edit_form':
       module_load_include('inc', 'basic_ingest', 'includes/utilities');
@@ -45,6 +47,8 @@ EOHELP;
 </ul>
 EOHELP;
       }
+      break;
+
   }
 }
 


### PR DESCRIPTION
When on a node add/edit page that's *not* an islandora_object type,
this was not properly exiting the switch statement because it wasn't
getting to the return statement. So it was entering the next case
of the switch statement and returning the media use help text.