### PR TITLE
FDSF4-221: Do not hardcode help text

### DIFF
--- a/basic_ingest.install
+++ b/basic_ingest.install
@@ -6,22 +6,19 @@
  */
 
 /**
- * Implements hook_update_N().
- *
- * Moves the help text for the Repository Item content type to the
- * node type configuration so that it's not hardcoded in the form.
+ * Moves the help text to config.
  */
-function basic_ingest_update_8001() {
-  $repository_help_text = <<<EOHELP
-<p>Adding this Repository Item to a collection isn't required, but can be used to organize items for display purposes. Use the 'Add container' button to faciliate multiple collection inheritancy.</p>
-<p>When creating a Repository Item using the 'Collection' content type, you will also be asked to optionally provide a 'Representative Image'; this will be used as a thumbnail, as well as in other situations where an image representative of the collection may be desirable.</p>
-<p>By default, if any Media types are associated with the selected content type, you will be redirected to the Media ingest page after clicking 'Save'.</p>
-<p>Uncheck 'Published' to keep this Repository Item out of public view. Unpublished items will still be preserved.</p>
-EOHELP;
+function basic_ingest_update_9001() {
+  $help_text = <<<EOHELP
+ <p>Adding this Repository Item to a collection isn't required, but can be used to organize items for display purposes. Use the 'Add container' button to facilitate multiple collection inheritance.</p>
+ <p>When creating a Repository Item using the 'Collection' content type, you will also be asked to optionally provide a 'Representative Image'; this will be used as a thumbnail, as well as in other situations where an image representative of the collection may be desirable.</p>
+ <p>By default, if any Media types are associated with the selected content type, you will be redirected to the Media ingest page after clicking 'Save'.</p>
+ <p>Uncheck 'Published' to keep this Repository Item out of public view. Unpublished items will still be preserved.</p>
+ EOHELP;
 
-  // Move the node help text to the node config
-  // so that it's not hardcoded in the form.
+  $current_help_text = \Drupal::config('node.type.islandora_object')
+    ->get('help') ?: '';
   \Drupal::service('config.factory')->getEditable('node.type.islandora_object')
-    ->set('help', $repository_help_text)
+    ->set('help', $current_help_text . PHP_EOL . $help_text)
     ->save();
 }

--- a/basic_ingest.install
+++ b/basic_ingest.install
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Update functions for the Basic Ingest module.
+ */
+
+/**
+ * Implements hook_update_N().
+ *
+ * Moves the help text for the Repository Item content type to the
+ * node type configuration so that it's not hardcoded in the form.
+ */
+function basic_ingest_update_8001() {
+  $repository_help_text = <<<EOHELP
+<p>Adding this Repository Item to a collection isn't required, but can be used to organize items for display purposes. Use the 'Add container' button to faciliate multiple collection inheritancy.</p>
+<p>When creating a Repository Item using the 'Collection' content type, you will also be asked to optionally provide a 'Representative Image'; this will be used as a thumbnail, as well as in other situations where an image representative of the collection may be desirable.</p>
+<p>By default, if any Media types are associated with the selected content type, you will be redirected to the Media ingest page after clicking 'Save'.</p>
+<p>Uncheck 'Published' to keep this Repository Item out of public view. Unpublished items will still be preserved.</p>
+EOHELP;
+
+  // Move the node help text to the node config
+  // so that it's not hardcoded in the form.
+  \Drupal::service('config.factory')->getEditable('node.type.islandora_object')
+    ->set('help', $repository_help_text)
+    ->save();
+}

--- a/basic_ingest.install
+++ b/basic_ingest.install
@@ -19,6 +19,6 @@ function basic_ingest_update_9001() {
   $current_help_text = \Drupal::config('node.type.islandora_object')
     ->get('help') ?: '';
   \Drupal::service('config.factory')->getEditable('node.type.islandora_object')
-    ->set('help', $current_help_text . PHP_EOL . $help_text)
+    ->set('help', $help_text . PHP_EOL . $current_help_text)
     ->save();
 }

--- a/basic_ingest.module
+++ b/basic_ingest.module
@@ -5,31 +5,18 @@
  * General hook implementations.
  */
 
-use Drupal\basic_ingest\Form\FieldModelToMedia;
-use Drupal\basic_ingest\Form\NodeMediaRedirect;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Field\Plugin\Field\FieldWidget\OptionsWidgetBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\basic_ingest\Form\FieldModelToMedia;
+use Drupal\basic_ingest\Form\NodeMediaRedirect;
 
 /**
  * Implements hook_help() for adding/editing Media and Resource Items.
  */
 function basic_ingest_help($route_name, RouteMatchInterface $route_match) {
   switch ($route_name) {
-    case 'node.add':
-    case 'node.edit':
-      $node_type = $route_match->getParameter('node_type');
-      if ($node_type && $node_type->get('type') == 'islandora_object') {
-        return <<<EOHELP
-<p>Adding this Repository Item to a collection isn't required, but can be used to organize items for display purposes. Use the 'Add container' button to faciliate multiple collection inheritancy.</p>
-<p>When creating a Repository Item using the 'Collection' content type, you will also be asked to optionally provide a 'Representative Image'; this will be used as a thumbnail, as well as in other situations where an image representative of the collection may be desirable.</p>
-<p>By default, if any Media types are associated with the selected content type, you will be redirected to the Media ingest page after clicking 'Save'.</p>
-<p>Uncheck 'Published' to keep this Repository Item out of public view. Unpublished items will still be preserved.</p>
-EOHELP;
-      }
-      break;
-
     case 'entity.media.add_form':
     case 'entity.media.edit_form':
       \Drupal::moduleHandler()->loadInclude('basic_ingest', 'inc', 'includes/utilities');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository Item help text is now added to the content type’s help field so it can be managed via configuration rather than being hardcoded.

* **Documentation**
  * Updated help content shown on add/edit pages.
  * Node add/edit screens now display the generic media-use guidance instead of the previous Islandora Object–specific instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->